### PR TITLE
fix: Pass username to regctl login

### DIFF
--- a/regctl-login/action.yml
+++ b/regctl-login/action.yml
@@ -22,4 +22,4 @@ runs:
   steps:
     - shell: bash
       run: |
-        echo "${{ inputs.password }}" | regctl registry login "${{ inputs.registry }}" -u "${{ inputs.user }}" --pass-stdin
+        echo "${{ inputs.password }}" | regctl registry login "${{ inputs.registry }}" -u "${{ inputs.username }}" --pass-stdin


### PR DESCRIPTION
Due to a misnamed variable, the login action would always pass an empty string as username to `regctl registry login`.