### PR TITLE
Refactoring cmd-installer path

### DIFF
--- a/regbot-installer/action.yml
+++ b/regbot-installer/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: ./cmd-installer
+    - uses: regclient/actions/cmd-installer@${{ github.ref_name }}
       with:
         install-cmd: regbot
         release: ${{ inputs.release }}

--- a/regctl-installer/action.yml
+++ b/regctl-installer/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: ./cmd-installer
+    - uses: regclient/actions/cmd-installer@${{ github.ref_name }}
       with:
         install-cmd: regctl
         release: ${{ inputs.release }}

--- a/regsync-installer/action.yml
+++ b/regsync-installer/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: ./cmd-installer
+    - uses: regclient/actions/cmd-installer@${{ github.ref_name }}
       with:
         install-cmd: regsync
         release: ${{ inputs.release }}


### PR DESCRIPTION
# Issue
If you use this action elsewhere, it will attempt to locate the `cmd-installer` within the repository where the action has been utilized. Resulting in an error like this:
```
Run regclient/actions/regctl-installer@main
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/my-repo/my-code/cmd-installer'. Did you forget to run actions/checkout before running your local action?
```

# Solution
The action path for `cmd-installer` should include the absolute path to the repository and the branch. I'm not sure if the refactoring I'm suggesting works fine, `@${{ github.ref_name }}` is probably wrong.