### PR TITLE
Fix: Expand $HOME variable in default install directory

### DIFF
--- a/regbot-installer/action.yml
+++ b/regbot-installer/action.yml
@@ -12,7 +12,6 @@ inputs:
   install-dir:
     description: 'where to install the binary'
     required: false
-    default: '$HOME/.regbot/bin'
 runs:
   using: 'composite'
   steps:
@@ -32,6 +31,10 @@ runs:
           alias log_info="echo \"INFO:\""
           alias log_error="echo \"ERROR:\""
         fi
+        if [ -z "${INSTALL_DIR}" ]; then
+          INSTALL_DIR="${HOME}/.regbot/bin"
+        fi
+        log_info "installing to ${INSTALL_DIR}"
         mkdir -p "${INSTALL_DIR}"
         url_base="https://github.com/regclient/regclient"
         url_ext=""
@@ -63,6 +66,7 @@ runs:
         curl -sL "${url_base}/${url_release}/${INSTALL_CMD}-${url_platform}${url_ext}" -o "${INSTALL_DIR}/${INSTALL_CMD}${url_ext}"
         chmod +x "${INSTALL_DIR}/${INSTALL_CMD}${url_ext}"
         if [ -x "$(command -v cosign)" ]; then
+          log_info "verifying cosign signature"
           curl -L "${url_base}/${url_release}/metadata.tgz" >metadata.tgz
           # first try to verify the bundle
           if tar -xzf metadata.tgz "${INSTALL_CMD}-${url_platform}.sigstore.json"; then
@@ -86,14 +90,16 @@ runs:
             rm metadata.tgz
           fi
         fi
+        echo "${INSTALL_DIR}" >> $GITHUB_PATH
         log_info "install complete"
-    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-      shell: bash
-      env:
-        INSTALL_DIR: ${{ inputs.install-dir }}
-      run:  echo "${INSTALL_DIR}" >> $GITHUB_PATH
     - if: ${{ runner.os == 'Windows' }}
       shell: pwsh
       env:
         INSTALL_DIR: ${{ inputs.install-dir }}
-      run:  echo "$env:INSTALL_DIR" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      run: |
+        $installdir = "$env:INSTALL_DIR"
+        if (!$installdir) {
+          $installdir = Join-Path $HOME '.regbot\bin'
+        }
+        echo "Adding to path $installdir"
+        echo "$installdir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/regctl-installer/action.yml
+++ b/regctl-installer/action.yml
@@ -12,7 +12,6 @@ inputs:
   install-dir:
     description: 'where to install the binary'
     required: false
-    default: '$HOME/.regctl/bin'
 runs:
   using: 'composite'
   steps:
@@ -32,6 +31,10 @@ runs:
           alias log_info="echo \"INFO:\""
           alias log_error="echo \"ERROR:\""
         fi
+        if [ -z "${INSTALL_DIR}" ]; then
+          INSTALL_DIR="${HOME}/.regctl/bin"
+        fi
+        log_info "installing to ${INSTALL_DIR}"
         mkdir -p "${INSTALL_DIR}"
         url_base="https://github.com/regclient/regclient"
         url_ext=""
@@ -63,6 +66,7 @@ runs:
         curl -sL "${url_base}/${url_release}/${INSTALL_CMD}-${url_platform}${url_ext}" -o "${INSTALL_DIR}/${INSTALL_CMD}${url_ext}"
         chmod +x "${INSTALL_DIR}/${INSTALL_CMD}${url_ext}"
         if [ -x "$(command -v cosign)" ]; then
+          log_info "verifying cosign signature"
           curl -L "${url_base}/${url_release}/metadata.tgz" >metadata.tgz
           # first try to verify the bundle
           if tar -xzf metadata.tgz "${INSTALL_CMD}-${url_platform}.sigstore.json"; then
@@ -86,14 +90,16 @@ runs:
             rm metadata.tgz
           fi
         fi
+        echo "${INSTALL_DIR}" >> $GITHUB_PATH
         log_info "install complete"
-    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-      shell: bash
-      env:
-        INSTALL_DIR: ${{ inputs.install-dir }}
-      run:  echo "${INSTALL_DIR}" >> $GITHUB_PATH
     - if: ${{ runner.os == 'Windows' }}
       shell: pwsh
       env:
         INSTALL_DIR: ${{ inputs.install-dir }}
-      run:  echo "$env:INSTALL_DIR" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      run: |
+        $installdir = "$env:INSTALL_DIR"
+        if (!$installdir) {
+          $installdir = Join-Path $HOME '.regctl\bin'
+        }
+        echo "Adding to path $installdir"
+        echo "$installdir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/regsync-installer/action.yml
+++ b/regsync-installer/action.yml
@@ -12,7 +12,6 @@ inputs:
   install-dir:
     description: 'where to install the binary'
     required: false
-    default: '$HOME/.regsync/bin'
 runs:
   using: 'composite'
   steps:
@@ -32,6 +31,10 @@ runs:
           alias log_info="echo \"INFO:\""
           alias log_error="echo \"ERROR:\""
         fi
+        if [ -z "${INSTALL_DIR}" ]; then
+          INSTALL_DIR="${HOME}/.regsync/bin"
+        fi
+        log_info "installing to ${INSTALL_DIR}"
         mkdir -p "${INSTALL_DIR}"
         url_base="https://github.com/regclient/regclient"
         url_ext=""
@@ -63,6 +66,7 @@ runs:
         curl -sL "${url_base}/${url_release}/${INSTALL_CMD}-${url_platform}${url_ext}" -o "${INSTALL_DIR}/${INSTALL_CMD}${url_ext}"
         chmod +x "${INSTALL_DIR}/${INSTALL_CMD}${url_ext}"
         if [ -x "$(command -v cosign)" ]; then
+          log_info "verifying cosign signature"
           curl -L "${url_base}/${url_release}/metadata.tgz" >metadata.tgz
           # first try to verify the bundle
           if tar -xzf metadata.tgz "${INSTALL_CMD}-${url_platform}.sigstore.json"; then
@@ -86,14 +90,16 @@ runs:
             rm metadata.tgz
           fi
         fi
+        echo "${INSTALL_DIR}" >> $GITHUB_PATH
         log_info "install complete"
-    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-      shell: bash
-      env:
-        INSTALL_DIR: ${{ inputs.install-dir }}
-      run:  echo "${INSTALL_DIR}" >> $GITHUB_PATH
     - if: ${{ runner.os == 'Windows' }}
       shell: pwsh
       env:
         INSTALL_DIR: ${{ inputs.install-dir }}
-      run:  echo "$env:INSTALL_DIR" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      run: |
+        $installdir = "$env:INSTALL_DIR"
+        if (!$installdir) {
+          $installdir = Join-Path $HOME '.regsync\bin'
+        }
+        echo "Adding to path $installdir"
+        echo "$installdir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Fixes #40 
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Note the installed location in GHA.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Expand $HOME variable in default install directory.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
